### PR TITLE
removed proxy arg group

### DIFF
--- a/src/cmd/app.rs
+++ b/src/cmd/app.rs
@@ -87,15 +87,6 @@ fn proxy_args(app: App<'static, 'static>) -> App<'static, 'static> {
                     .help("The domain name of the https proxy")
                     .required_if("proxy-scheme", "https"),
             )
-            .group(ArgGroup::with_name("proxy").args(
-                &[
-                    "proxy-host",
-                    "proxy-scheme",
-                    "proxy-credentials",
-                    "proxy-https-domain",
-                    "proxy-https-cafile",
-                ][..],
-            ))
     } else {
         app.group(
             ArgGroup::with_name("proxy")


### PR DESCRIPTION
I found a bug.

```
$ sudo ./target/debug/doh-client -l 0.0.0.0:53  -d dns.google -r dns.google:443 --proxy-host 192.168.1.108:3128 --proxy-scheme http /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
error: The argument '--proxy-scheme <proxy-scheme>' cannot be used with one or more of the other specified arguments
```
I think the arguments group 'proxy' makes this error.
