### PR TITLE
Add clone3 to permitted system calls

### DIFF
--- a/package/linux/doh-client.service
+++ b/package/linux/doh-client.service
@@ -49,9 +49,9 @@ SecureBits=no-cap-ambient-raise,no-cap-ambient-raise-locked
 # System Call Filtering
 ## syscall filter for the current Arch Linux kernel (remove it for other distros if it causes
 ## problems)
-SystemCallFilter=access arch_prctl bind brk clone close connect epoll_create1 epoll_ctl epoll_wait
-SystemCallFilter=eventfd2 execve fcntl futex getrandom getsockopt ioctl mmap mprotect munmap
-SystemCallFilter=newfstatat openat poll prctl pread64 prlimit64 read recvfrom rt_sigaction
+SystemCallFilter=access arch_prctl bind brk clone clone3 close connect epoll_create1 epoll_ctl
+SystemCallFilter=epoll_wait eventfd2 execve fcntl futex getrandom getsockopt ioctl mmap mprotect
+SystemCallFilter=munmap newfstatat openat poll prctl pread64 prlimit64 read recvfrom rt_sigaction
 SystemCallFilter=rt_sigprocmask sched_getaffinity sendto set_robust_list set_tid_address setsockopt
 SystemCallFilter=sigaltstack socket statx write writev
 ##


### PR DESCRIPTION
I’m on Arch Linux and my latest system update broke doh-client. I got an error message saying it couldn’t spawn a thread, permission denied. I’m not sure exactly what changed but I figured out that adding clone3 to the system call filter fixes it.

Edit: for reference, I believe this was the change that caused the problem: https://github.com/archlinux/svntogit-packages/commit/14abe44a37dedc67d11563122502b62896ecf94f
clone3 used to be disabled in glibc on Arch but was just re-enabled.